### PR TITLE
Camera lock fix for Android 7.1.1 AOSP

### DIFF
--- a/app/src/main/java/com/exlyo/camerarestarter/MainActivity.java
+++ b/app/src/main/java/com/exlyo/camerarestarter/MainActivity.java
@@ -310,7 +310,9 @@ public class MainActivity extends AppCompatActivity {
 				//Command to kill the process using the file "/system/bin/mediaserver" under the "media" user name
 				createKillCommandForSystemBin("media", "mediaserver")
 					//Command to kill the process using the file "/system/bin/cameraserver" under the "camera" user name
-					+ createKillCommandForSystemBin("camera", "cameraserver");
+					+ createKillCommandForSystemBin("camera", "cameraserver")
+						//Command to kill the process using the file "/system/bin/mm-qcamera-daemon" under the "camera" user name
+						+ createKillCommandForSystemBin("camera", "mm-qcamera-daemon");
 			os.writeBytes(command + "\n");
 		} finally {
 			if (os != null) {


### PR DESCRIPTION
Releases camera locks on Android 7.1.1 AOSP. Tested with Google Nexus 5. Restarting cameraserver did not solve the problem but restarting mm-qcamera-daemon finally released the camera.